### PR TITLE
Add Rocket-Booking actions and Switch badges

### DIFF
--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { rocketReserve } from '../redux/rockets/rockets';
 
 const Rocket = (props) => {
+  const dispatch = useDispatch();
   const { rocket } = props;
   return (
     <div className="card flex">
@@ -8,22 +11,28 @@ const Rocket = (props) => {
         <img src={rocket.flickr_images[0]} alt={rocket.rocket_name} />
       </div>
 
-      <div>
+      <div className="content">
         <div>
           <span className="rocket-name">{rocket.rocket_name}</span>
         </div>
         <div className="description">
+          {rocket.reserved ? <span className="badge">Reserved</span> : ''}
           <span>{rocket.description}</span>
         </div>
+        <button type="submit" className={rocket.reserved ? 'reserved' : 'not-reserved'} onClick={() => dispatch(rocketReserve(rocket.rocket_id))}>
+          {rocket.reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
+        </button>
       </div>
     </div>
   );
 };
 Rocket.propTypes = {
   rocket: PropTypes.shape({
+    rocket_id: PropTypes.string,
     rocket_name: PropTypes.string,
     description: PropTypes.string,
     flickr_images: PropTypes.arrayOf(PropTypes.string),
+    reserved: PropTypes.bool,
   }).isRequired,
 };
 export default Rocket;

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -10,12 +10,20 @@ const initialState = [];
 const rocketsSlice = createSlice({
   name: 'rockets',
   initialState,
-  reducers: {},
+  reducers: {
+    rocketReserve: (state, action) => state.map((rocket) => {
+      if (rocket.rocket_id === action.payload) {
+        return { ...rocket, reserved: !rocket.reserved };
+      }
+      return rocket;
+    }),
+  },
   extraReducers: (builder) => {
     builder.addCase(fetchRockets.fulfilled, (state, action) => action.payload);
   },
 });
 
 const { actions, reducer } = rocketsSlice;
-export { actions, fetchRockets };
+const { rocketReserve } = actions;
+export { actions, fetchRockets, rocketReserve };
 export default reducer;

--- a/src/styles/Rockets.css
+++ b/src/styles/Rockets.css
@@ -15,6 +15,10 @@
   width: 400px;
 }
 
+.content {
+  width: 60%;
+}
+
 .rocket-name {
   font-size: 25px;
   line-height: 40px;
@@ -22,4 +26,31 @@
 
 .description {
   margin: 10px 0;
+  line-height: 30px;
+}
+
+button {
+  cursor: pointer;
+}
+
+.badge {
+  margin-right: 10px;
+  padding: 5px;
+  border-radius: 5px;
+  background-color: aqua;
+  color: rgb(11, 13, 77);
+  font-weight: bold;
+}
+
+.reserved {
+  padding: 10px;
+  background-color: #3c3c3c;
+  color: #fff;
+}
+
+.not-reserved {
+  padding: 10px;
+  background-color: #000;
+  border: 1px solid #fff;
+  color: #fff;
 }


### PR DESCRIPTION
# **Add the following features:**

- **When a user clicks the "Reserve rocket" button, action needs to be dispatched to update the store.**
- **Follow the same logic as with the "Reserve rocket" - but you need to set the reserved key to false.**
- **Dispatch these actions upon click on the corresponding buttons.**
- **Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)**